### PR TITLE
cabal-plan.cabal: allow ansi-terminal version 0.7.x

### DIFF
--- a/cabal-plan.cabal
+++ b/cabal-plan.cabal
@@ -93,7 +93,7 @@ executable cabal-plan
 
     -- dependencies which require version bounds
     build-depends: mtl            ^>= 2.2.1
-                 , ansi-terminal  ^>= 0.6.2
+                 , ansi-terminal   >= 0.6.2 && < 0.8
                  , base-compat    ^>= 0.9.3
                  , optparse-applicative ^>= 0.13.0 || ^>= 0.14.0
                  , parsec         ^>= 3.1.11


### PR DESCRIPTION
The build works fine with newer version. I tried whether we can support ansi-terminal 0.8.x, even, but then I ran into other version constraints further down the dependency chain and didn't pursue the subject. Supporting 0.7.x should be good enough, since that's the version currently recommended by LTS-10.x anyway.