### PR TITLE
Also "look" for implicit cabal.project files.

### DIFF
--- a/cabal-plan.cabal
+++ b/cabal-plan.cabal
@@ -90,6 +90,7 @@ executable cabal-plan
                  , text
                  , containers
                  , bytestring
+                 , directory
 
     -- dependencies which require version bounds
     build-depends: mtl            ^>= 2.2.1

--- a/src-exe/cabal-plan.hs
+++ b/src-exe/cabal-plan.hs
@@ -32,6 +32,7 @@ import qualified Data.Vector.Unboxed.Mutable as MU
 import           Data.Version
 import           Options.Applicative
 import           System.Console.ANSI
+import           System.Directory            (getCurrentDirectory)
 import           System.Exit                 (exitFailure)
 import           System.IO                   (hPutStrLn, stderr)
 import qualified Text.Parsec                 as P
@@ -111,7 +112,7 @@ parsePattern = either (Left . show) Right . P.runParser (patternP <* P.eof) () "
 
 patternCompleter :: Bool -> Completer
 patternCompleter onlyWithExes = mkCompleter $ \pfx -> do
-    (plan, _) <- findAndDecodePlanJson Nothing
+    (plan, _) <- getCurrentDirectory >>= findAndDecodePlanJson Nothing
     let tpfx  = T.pack pfx
         components = findComponents plan
 
@@ -234,7 +235,7 @@ highlightParser = pathParser <|> revdepParser
 main :: IO ()
 main = do
     GlobalOptions{..} <- execParser $ info (helper <*> optVersion <*> optParser) fullDesc
-    val@(plan, _) <- findAndDecodePlanJson buildDir
+    val@(plan, _) <- getCurrentDirectory >>= findAndDecodePlanJson buildDir
     case cmd of
       InfoCommand -> doInfo val
       ShowCommand -> print val

--- a/src/Cabal/Plan.hs
+++ b/src/Cabal/Plan.hs
@@ -311,7 +311,7 @@ findAndDecodePlanJson searchLoc = do
             mRoot <- findProjectRoot fp
             case mRoot of
                 Nothing -> fail ("missing project root relative to: " ++ fp)
-                Just dir -> pure dir
+                Just dir -> pure $ dir </> "dist-newstyle"
 
     haveDistFolder <- Dir.doesDirectoryExist distFolder
 

--- a/src/Cabal/Plan.hs
+++ b/src/Cabal/Plan.hs
@@ -345,7 +345,8 @@ decodePlanJson planJsonFn = do
 -- function also considers *.cabal files in directories higher up in the
 -- hierarchy.
 findProjectRoot :: FilePath -> IO (Maybe FilePath)
-findProjectRoot cwd = do
+findProjectRoot dir = do
+    normalisedPath <- Dir.canonicalizePath dir
     let checkCabalProject d = do
             ex <- Dir.doesFileExist fn
             return $ if ex then Just d else Nothing
@@ -358,10 +359,10 @@ findProjectRoot cwd = do
                         then Just d
                         else Nothing
 
-    result <- walkUpFolders checkCabalProject cwd
+    result <- walkUpFolders checkCabalProject normalisedPath
     case result of
-        Just dir -> pure $ Just dir
-        Nothing -> walkUpFolders checkCabal cwd
+        Just rootDir -> pure $ Just rootDir
+        Nothing -> walkUpFolders checkCabal normalisedPath
   where
     isExtensionOf :: String -> FilePath -> Bool
     isExtensionOf ext fp = ext == takeExtension fp


### PR DESCRIPTION
After a bunch of monologuing on IRC I think the way to deal with implicit cabal.project files is actually rather simple, as they can only happen in directories with *.cabal and only if there's no explicit cabal.project anywhere.

Before cabal-plan didn't consider implicit cabal.project files, now it handles them slightly more liberally than cabal-install. Since cabal-install only considers implicit configs if the CWD has *.cabal files. This change looks for *.cabal files anywhere higher in the hierarchy (which is useful when run inside, e.g. a source directory).