### PR TITLE
Add cabal target-selector compatible pretty printer for CompName

### DIFF
--- a/src-exe/LicenseReport.hs
+++ b/src-exe/LicenseReport.hs
@@ -206,7 +206,7 @@ generateLicenseReport mlicdir plan uid0 cn0 = do
     T.putStrLn ("Bold-faced **`package-name`**s denote standard libraries bundled with `" <> dispPkgId (pjCompilerId plan) <> "`.")
     T.putStrLn ""
 
-    T.putStrLn ("## Direct dependencies of `" <> unPkgN pn0 <> ":" <> dispCompName cn0 <> "`")
+    T.putStrLn ("## Direct dependencies of `" <> unPkgN pn0 <> ":" <> dispCompNameTarget pn0 cn0 <> "`")
     T.putStrLn ""
     T.putStrLn "| Name | Version | [SPDX](https://spdx.org/licenses/) License Id | Description | Also depended upon by |"
     T.putStrLn "| --- | --- | --- | --- | --- |"

--- a/src/Cabal/Plan.hs
+++ b/src/Cabal/Plan.hs
@@ -14,6 +14,7 @@ module Cabal.Plan
     , Unit(..)
     , CompName(..)
     , dispCompName
+    , dispCompNameTarget
     , CompInfo(..)
     , UnitType(..)
 
@@ -300,7 +301,16 @@ parseCompName t0 = case T.splitOn ":" t0 of
                      ["setup"]   -> Just CompNameSetup
                      _           -> Nothing
 
--- | Pretty print 'CompName'
+-- | Pretty print 'CompName' in cabal's target-selector syntax.
+dispCompNameTarget :: PkgName -> CompName -> Text
+dispCompNameTarget (PkgName pkg) cn = case cn of
+    CompNameLib      -> "lib:" <> pkg
+    _                -> dispCompName cn
+
+-- | Pretty print 'CompName' in the same syntax that is used in
+-- @plan.json@. Note that this string can not be used as a target-selector on
+-- the cabal command-line. See 'dispCompNameTarget' for a target-selector
+-- compatible pretty printer.
 dispCompName :: CompName -> Text
 dispCompName cn = case cn of
     CompNameLib      -> "lib"


### PR DESCRIPTION
Currently `dispCompName CompNameLib` would just print `"lib"` however this
syntax is neither accepted by `cabal v1-build` nor `v2-build` as a valid target
selector making it somewhat useless for that use-case.

To specify a main library as a target selector one has to use the
`<namespace>:<component name>` syntax where `<component name>` is the name of
the respective package for unqualified libraries.

Hence this commit adds new function `dispCompName` with an additional `PkgName`
argument.