### PR TITLE
Update deps, add disambiguate and subparserInline

### DIFF
--- a/cabal-plan.cabal
+++ b/cabal-plan.cabal
@@ -108,14 +108,15 @@ executable cabal-plan
     build-depends: mtl            ^>= 2.2.1
                  , transformers   ^>= 0.3.0.0 || ^>= 0.4.2.0 || ^>= 0.5.2.0
                  , ansi-terminal  ^>= 0.9
-                 , base-compat    ^>= 0.9.3 || ^>=0.10.1
-                 , optparse-applicative ^>= 0.13.0 || ^>= 0.14.0
+                 , base-compat    ^>= 0.10.5
+                 , optparse-applicative ^>= 0.15.0.0
                  , parsec         ^>= 3.1.11
                  , transformers   ^>= 0.3.0.0 || ^>=0.4.2.0 || ^>= 0.5.2.0
                  , topograph      ^>= 1
                  , vector         ^>= 0.12.0.1
                  , lens           ^>= 4.17
-                 , these          ^>= 0.8
+                 , these          ^>= 1
+                 , semialign      ^>= 1
                  , singleton-bool ^>= 0.1.4
 
     if flag(license-report)

--- a/src-exe/cabal-plan.hs
+++ b/src-exe/cabal-plan.hs
@@ -259,7 +259,8 @@ highlightParser = pathParser <|> revdepParser
 
 main :: IO ()
 main = do
-    GlobalOptions{..} <- execParser $ info (helper <*> optVersion <*> optParser) fullDesc
+    let prefs' = prefs $ disambiguate <> subparserInline
+    GlobalOptions{..} <- customExecParser prefs' $ info (helper <*> optVersion <*> optParser) fullDesc
 
     case cmd of
       InfoCommand s -> do


### PR DESCRIPTION
Now we can say both

```
cabal-plan list-bins --color=auto --builddir=dist-newstyle
cabal-plan list-bins --builddir=dist-newstyle --color-auto
```

previously (in `master`) only latter worked, as `--color=auto` is
"global" option, and it's not parsed inside command subparser.
(In this case --color setting doesn't matter, but it's an example).

This is good reason to require newer optparse-applicative