### PR TITLE
Use optics instead of lens

### DIFF
--- a/cabal-plan.cabal
+++ b/cabal-plan.cabal
@@ -109,18 +109,17 @@ executable cabal-plan
 
     -- dependencies which require version bounds
     build-depends: mtl            ^>= 2.2.1
-                 , transformers   ^>= 0.3.0.0 || ^>= 0.4.2.0 || ^>= 0.5.2.0
                  , ansi-terminal  ^>= 0.9 || ^>=0.10
                  , base-compat    ^>= 0.10.5 || ^>=0.11
+                 , optics-core    ^>= 0.1
                  , optparse-applicative ^>= 0.15.0.0
                  , parsec         ^>= 3.1.11
-                 , transformers   ^>= 0.3.0.0 || ^>=0.4.2.0 || ^>= 0.5.2.0
-                 , topograph      ^>= 1
-                 , vector         ^>= 0.12.0.1
-                 , lens           ^>= 4.17 || ^>=4.18
-                 , these          ^>= 1
                  , semialign      ^>= 1
                  , singleton-bool ^>= 0.1.4
+                 , these          ^>= 1
+                 , topograph      ^>= 1
+                 , transformers   ^>= 0.3.0.0 || ^>= 0.4.2.0 || ^>= 0.5.2.0
+                 , vector         ^>= 0.12.0.1
 
     if flag(license-report)
       build-depends: Cabal    ^>= 2.2.0.1 || ^>= 2.4.0.1 || ^>= 3.0.0.0

--- a/src-exe/cabal-plan.hs
+++ b/src-exe/cabal-plan.hs
@@ -11,7 +11,6 @@ module Main where
 import           Prelude                     ()
 import           Prelude.Compat
 
-import           Control.Lens                (ifor_)
 import           Control.Monad.Compat        (forM_, guard, unless, when, ap)
 import           Control.Monad.State.Strict  (StateT, modify', evalStateT, gets)
 import           Control.Monad.Trans.Class   (lift)
@@ -36,6 +35,7 @@ import           Data.Tuple                  (swap)
 import qualified Data.Vector.Unboxed         as U
 import qualified Data.Vector.Unboxed.Mutable as MU
 import           Data.Version
+import           Optics.Indexed.Core         (ifor_)
 import           Options.Applicative
 import           System.Console.ANSI
 import           System.Directory            (getCurrentDirectory)


### PR DESCRIPTION
We dependend on `lens` only for `ifor_`;
`optics-core` gives the same with smaller dependency footprint.