### PR TITLE
Build with GHC 9.2.1+

### DIFF
--- a/cabal-plan.cabal
+++ b/cabal-plan.cabal
@@ -74,9 +74,9 @@ library
                        RecordWildCards
   exposed-modules:     Cabal.Plan
 
-  build-depends:       base              ^>= 4.10 || ^>=4.11 || ^>=4.12 || ^>=4.13 || ^>=4.14 || ^>=4.15
+  build-depends:       base              ^>= 4.10 || ^>=4.11 || ^>=4.12 || ^>=4.13 || ^>=4.14 || ^>=4.15 || ^>=4.16
                      , aeson             ^>= 1.5.4.0 || ^>= 2.0.0.0
-                     , bytestring        ^>= 0.10.8.0
+                     , bytestring        ^>= 0.10.8.0 || ^>=0.11.1.0
                      , containers        ^>= 0.5.10 || ^>= 0.6.0.1
                      , text              ^>= 1.2.3
                      , directory         ^>= 1.3.0


### PR DESCRIPTION
helps build with GHC 9.2.1+ with base 4.16 and new bytestring version buildable with base 4.16+