### PR TITLE
Allow ansi-terminal-1.0

### DIFF
--- a/cabal-plan.cabal
+++ b/cabal-plan.cabal
@@ -114,7 +114,7 @@ executable cabal-plan
     -- dependencies which require version bounds
     build-depends: mtl            ^>= 2.2.2 || ^>=2.3.1
                  , async          ^>= 2.2.2
-                 , ansi-terminal  ^>= 0.11
+                 , ansi-terminal  ^>= 0.11 || ^>=1.0
                  , base-compat    ^>= 0.13.0
                  , optics-core    ^>= 0.4
                  , optparse-applicative ^>=0.17.0.0


### PR DESCRIPTION
This is a prerequisite for inclusion into current Stackage.

Tested using `--constraint 'ansi-terminal ^>= 1.0'`
