### PR TITLE
Remove blank line from end of license report

### DIFF
--- a/src-exe/LicenseReport.hs
+++ b/src-exe/LicenseReport.hs
@@ -239,7 +239,6 @@ generateLicenseReport mlicdir plan uid0 cn0 = do
     T.putStrLn "| Name | Version | [SPDX](https://spdx.org/licenses/) License Id | Description | Depended upon by |"
     T.putStrLn "| --- | --- | --- | --- | --- |"
     forM_ indirectDeps $ printInfo
-    T.putStrLn ""
 
     pure ()
 


### PR DESCRIPTION
`printInfo` uses `putStrLn`, so it already has the requisite trailing newline. The extra `putStrLn` just adds an additional blank line.

Using a mix of automated diffing and manual editing to keep the license report current, this causes some issues, as editors often like to trim trailing blank lines (especially for text formats like Markdown), and that then plays havoc with the diffs.